### PR TITLE
Add start and stop endpoints

### DIFF
--- a/replikator-api.go
+++ b/replikator-api.go
@@ -60,17 +60,6 @@ func createReplikator(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, output)
 }
 
-func refreshReplikator(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	name := vars["name"]
-
-	log.Printf("Refreshing replikator: %s", name)
-
-	output := execute("-o json --refresh " + name)
-
-	fmt.Fprint(w, output)
-}
-
 func getReplikator(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["name"]
@@ -97,7 +86,6 @@ func startApiServer() {
 	r.HandleFunc("/replikators", listReplikators).Methods("GET")
 
 	r.HandleFunc("/replikator/{name}", createReplikator).Methods("PUT")
-	r.HandleFunc("/replikator/{name}/refresh", refreshReplikator).Methods("PUT")
 	r.HandleFunc("/replikator/{name}", getReplikator).Methods("GET")
 	r.HandleFunc("/replikator/{name}", deleteReplikator).Methods("DELETE")
 

--- a/replikator-api.go
+++ b/replikator-api.go
@@ -60,6 +60,28 @@ func createReplikator(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, output)
 }
 
+func stopReplikator(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	name := vars["name"]
+
+	log.Printf("Stopping replikator: %s", name)
+
+	output := execute("-o json --stop " + name)
+
+	fmt.Fprint(w, output)
+}
+
+func startReplikator(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	name := vars["name"]
+
+	log.Printf("Starting replikator: %s", name)
+
+	output := execute("-o json --run " + name)
+
+	fmt.Fprint(w, output)
+}
+
 func getReplikator(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["name"]
@@ -86,6 +108,8 @@ func startApiServer() {
 	r.HandleFunc("/replikators", listReplikators).Methods("GET")
 
 	r.HandleFunc("/replikator/{name}", createReplikator).Methods("PUT")
+	r.HandleFunc("/replikator/{name}/stop", stopReplikator).Methods("PUT")
+	r.HandleFunc("/replikator/{name}/start", startReplikator).Methods("PUT")
 	r.HandleFunc("/replikator/{name}", getReplikator).Methods("GET")
 	r.HandleFunc("/replikator/{name}", deleteReplikator).Methods("DELETE")
 


### PR DESCRIPTION
```
⇒  curl --request GET http://HOST:8080/replikator/foo-bar
{
    "DatabaseProperties": {
        "iPort": 4000,
        "sIP": "10.11.12.13",
        "sInstanceId": "foo-bar"
    },
    "aFromIpPortRedirects": [],
    "dCreationDate": "1561472633",
    "eState": "RUNNING",
    "sMemUsed": "339.82 MB / 1 GB",
    "sMetas": {},
    "sPercentSizeFree": "n/a",
    "sPercentSizeUsed": "n/a",
    "sSizeTotal": "1.19 MB"
}

⇒  curl --request PUT http://HOST:8080/replikator/foo-bar/stop

⇒  curl --request GET http://HOST:8080/replikator/foo-bar
{
    "DatabaseProperties": {
        "iPort": 4000,
        "sIP": "10.11.12.13",
        "sInstanceId": "foo-bar"
    },
    "aFromIpPortRedirects": [],
    "dCreationDate": "1561472633",
    "eState": "STOPPED",
    "sMemUsed": "--- / 1 GB",
    "sMetas": {},
    "sPercentSizeFree": "n/a",
    "sPercentSizeUsed": "n/a",
    "sSizeTotal": "1.04 MB"
}

⇒  curl --request PUT http://HOST:8080/replikator/foo-bar/start
{}

⇒  curl --request GET http://HOST:8080/replikator/foo-bar
{
    "DatabaseProperties": {
        "iPort": 4000,
        "sIP": "10.11.12.13",
        "sInstanceId": "foo-bar"
    },
    "aFromIpPortRedirects": [],
    "dCreationDate": "1561472633",
    "eState": "RUNNING",
    "sMemUsed": "329.52 MB / 1 GB",
    "sMetas": {},
    "sPercentSizeFree": "n/a",
    "sPercentSizeUsed": "n/a",
    "sSizeTotal": "1.04 MB"
}
```