### PR TITLE
Reset replication lag as to clear labels that aren't used

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -101,6 +101,7 @@ func getMetrics() http.Handler {
 		if err != nil {
 			replicationLag = -1
 		}
+		replikatorReplicationLag.Reset()
 		replikatorReplicationLag.With(prometheus.Labels{"state": strings.ToLower(data.DatabaseGlobalState.ReplicationState)}).Set(replicationLag)
 
 		diskCapacity, _ := strconv.ParseFloat(data.DatabaseGlobalState.DiskCapacity, 64)


### PR DESCRIPTION
Without clearing, it would also report state=stopped and state=running at the same time if it ever stopped.