### PR TITLE
Don't kill child processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ User=replikator
 Group=replikator
 LimitNOFILE=1024
 
+KillMode=process
+
 Restart=on-failure
 RestartSec=10
 


### PR DESCRIPTION
When restarting or stopping the Replikator API we don't want the child processes (mysql instances/replicas) to be killed.